### PR TITLE
async test mocks and small additions to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,8 @@ dependencies = [
     "pydantic (>=2.11.7,<3.0.0)",
     "pandas (>=2.3.1,<3.0.0)",
     "prometheus-client (>=0.22.1,<0.23.0)",
-    "starlette (>=0.47.2,<0.48.0)"
+    "starlette (>=0.47.2,<0.48.0)",
+    "httpx (>=0.28.1,<0.29.0)"
 ]
 package-mode = false
 
@@ -29,6 +30,8 @@ black = "^25.1.0"
 pytest-mock = "^3.14.1"
 pylint = "^4.0.0"
 pytest-cov = "^7.0.0"
+httpx = "^0.28.1"
+pytest-asyncio = "^1.2.0"
 
 [tool.poetry.requires-plugins]
 poetry-plugin-export = ">=1.8"
@@ -40,7 +43,8 @@ build-backend = "poetry.core.masonry.api"
 [tool.poetry]
 package-mode = false
 
-
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
 
 [tool.black]
 line-length = 100

--- a/tests/clients/test_yfinance_client.py
+++ b/tests/clients/test_yfinance_client.py
@@ -1,0 +1,123 @@
+import pytest
+import pandas as pd
+import asyncio
+from fastapi import HTTPException
+
+from app.clients.yfinance_client import YFinanceClient
+
+
+@pytest.mark.asyncio
+async def test_fetch_data_upstream_timeout(monkeypatch):
+    """Simulate a TimeoutError -> should raise HTTP 503."""
+    client = YFinanceClient()
+
+    async def fake_to_thread(*args, **kwargs):
+        raise asyncio.TimeoutError("Simulated timeout")
+
+    monkeypatch.setattr(asyncio, "to_thread", fake_to_thread)
+
+    with pytest.raises(HTTPException) as excinfo:
+        await client._fetch_data("info", lambda: None, "AAPL")
+
+    assert excinfo.value.status_code == 503
+    assert "timeout" in excinfo.value.detail.lower()
+
+
+@pytest.mark.asyncio
+async def test_fetch_data_cancelled_task(monkeypatch):
+    """Simulate asyncio.CancelledError -> should raise HTTP 499."""
+    client = YFinanceClient()
+
+    async def fake_to_thread(*args, **kwargs):
+        raise asyncio.CancelledError()
+
+    monkeypatch.setattr(asyncio, "to_thread", fake_to_thread)
+
+    with pytest.raises(HTTPException) as excinfo:
+        await client._fetch_data("info", lambda: None, "AAPL")
+
+    assert excinfo.value.status_code == 499
+    assert "cancelled" in excinfo.value.detail.lower()
+
+
+@pytest.mark.asyncio
+async def test_get_info_non_dict(monkeypatch):
+    """Simulate malformed info (non-dict) -> should raise HTTP 502."""
+    client = YFinanceClient()
+    ticker_mock = type("TickerMock", (), {"get_info": lambda self: ["invalid"]})()
+    monkeypatch.setattr(client, "_get_ticker", lambda symbol: ticker_mock)
+
+    async def mock_fetch_data(*a, **kw):
+        return ["invalid"]
+
+    monkeypatch.setattr(client, "_fetch_data", mock_fetch_data)
+
+    with pytest.raises(HTTPException) as excinfo:
+        await client.get_info("AAPL")
+
+    assert excinfo.value.status_code == 502
+
+
+@pytest.mark.asyncio
+async def test_get_info_empty(monkeypatch):
+    """Simulate missing info (None or empty dict) -> should raise HTTP 404."""
+    client = YFinanceClient()
+
+    async def mock_fetch_data(*a, **kw):
+        return None
+
+    monkeypatch.setattr(client, "_fetch_data", mock_fetch_data)
+
+    with pytest.raises(HTTPException) as excinfo:
+        await client.get_info("AAPL")
+
+    assert excinfo.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_get_info_empty(monkeypatch):
+    """Simulate missing info (None or empty dict) -> should raise HTTP 404."""
+    client = YFinanceClient()
+
+    async def mock_fetch_data(*a, **kw):
+        return None
+
+    monkeypatch.setattr(client, "_fetch_data", mock_fetch_data)
+
+    with pytest.raises(HTTPException) as excinfo:
+        await client.get_info("AAPL")
+
+    assert excinfo.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_get_history_empty_df(monkeypatch):
+    """Simulate empty history -> should raise HTTP 404."""
+    client = YFinanceClient()
+    empty_df = pd.DataFrame()
+
+    async def mock_fetch_data(*a, **kw):
+        return empty_df
+
+    monkeypatch.setattr(client, "_fetch_data", mock_fetch_data)
+
+    with pytest.raises(HTTPException) as excinfo:
+        await client.get_history("AAPL", None, None)
+
+    assert excinfo.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_get_history_non_dataframe(monkeypatch):
+    """Simulate malformed history (not a DataFrame) -> should raise HTTP 502."""
+    client = YFinanceClient()
+
+    async def mock_fetch_data(*a, **kw):
+        return {"not": "df"}
+
+    monkeypatch.setattr(client, "_fetch_data", mock_fetch_data)
+
+    with pytest.raises(HTTPException) as excinfo:
+        await client.get_history("AAPL", None, None)
+
+    assert excinfo.value.status_code == 502


### PR DESCRIPTION
## Summary

This PR adds new automated tests to improve coverage and ensure the stability of the `yfinance` client layer. 

---

## Changes

### Introduced async test mocks
- Created tests in `tests/clients/test_yfinance_client.py` which use proper async-await patterns.  
- Added async-compatible mocks.

---

### Updated `pyproject.toml`

#### Adjusted metadata to include:
- `requires-python = ">=3.13"`

#### Added dev dependencies:
- `pytest-asyncio` for async test support  
- Set `asyncio_mode = "auto"` in pytest config for cleaner async tests.

#### Ensured compatibility with:

- pytest-asyncio
- httpx 

---

## Testing

All tests now run cleanly with Python 3.13:

bash
poetry install
pytest -v

---

## Motivation

- Recent versions of FastAPI, Starlette, and pytest require async-compatible test setups.
- This PR ensures developers can run the test suite smoothly on modern environments without manual patching.

---

## Notes

- Verified locally under Python 3.13.0

- No functional code changes to yfinance core

- Only testing and packaging configuration improvements

---

Closes: #37
