### PR TITLE
Updated service.py according to the requirements. Added tests in test_quote.py for the new changes in service.py

### DIFF
--- a/app/features/quote/service.py
+++ b/app/features/quote/service.py
@@ -68,44 +68,52 @@ def _parse_float(value: Any) -> float | None:
     except (TypeError, ValueError):
         return None
 
+def _raise_malformed_data(symbol: str) -> None:
+    logger.warning("quote.fetch.malformed_number", extra={"symbol": symbol})
+    raise HTTPException(
+        status_code=502,
+        detail=f"Malformed numeric data from upstream for {symbol}"
+    )
 
 def _map_quote(symbol: str, info: Info) -> QuoteResponse:
+    """Map upstream info to QuoteResponse, validating required fields."""
     mapped = _extract_logical_values(info)
 
+    # Check for missing required fields
     missing = [f for f in REQUIRED_FIELDS if mapped.get(f) is None]
     if missing:
-        logger.warning("quote.fetch.missing_fields", extra={"missing": missing})
+        logger.warning(
+            "quote.fetch.missing_fields",
+            extra={"symbol": symbol, "missing": missing}
+        )
         raise HTTPException(
             status_code=502,
-            detail=f"Missing required fields in upstream data: {', '.join(missing)}",
+            detail=f"Missing required fields in upstream data for {symbol}: {', '.join(missing)}",
         )
 
-    parse_float = _parse_float
-    try:
-        current = parse_float(mapped["current_price"])
-        previous = parse_float(mapped["previous_close"])
-        opened = parse_float(mapped["open"])
-        high = parse_float(mapped["high"])
-        low = parse_float(mapped["low"])
-    except Exception:
-        logger.warning("quote.fetch.malformed_number", extra={"symbol": symbol})
-        raise HTTPException(status_code=502, detail="Malformed numeric data from upstream")
+    # Parse required float fields in a loop
+    parsed_values: dict[str, float] = {}
+    for field in REQUIRED_FIELDS:
+        value = _parse_float(mapped[field])
+        if value is None:
+            _raise_malformed_data(symbol)
+        parsed_values[field] = value
 
-    if any(x is None for x in (current, previous, opened, high, low)):
-        logger.warning("quote.fetch.malformed_number", extra={"symbol": symbol})
-        raise HTTPException(status_code=502, detail="Malformed numeric data from upstream")
-
+    # Parse optional volume
     volume = _parse_int(mapped.get("volume"))
+    if mapped.get("volume") is not None and volume is None:
+        logger.warning("quote.fetch.malformed_volume", extra={"symbol": symbol})
 
     return QuoteResponse(
         symbol=symbol,
-        current_price=current,
-        previous_close=previous,
-        open_price=opened,
-        high=high,
-        low=low,
+        current_price=parsed_values["current_price"],
+        previous_close=parsed_values["previous_close"],
+        open_price=parsed_values["open"],
+        high=parsed_values["high"],
+        low=parsed_values["low"],
         volume=volume,
     )
+
 
 
 async def fetch_quote(symbol: str, client: YFinanceClientInterface) -> QuoteResponse:
@@ -118,6 +126,8 @@ async def fetch_quote(symbol: str, client: YFinanceClientInterface) -> QuoteResp
     Returns:
         QuoteResponse: The stock quote information.
 
+    Raises:
+        HTTPException: 400 for empty symbol, 502 for upstream issues.
     """
     symbol = symbol.upper().strip()
     if not symbol:
@@ -128,5 +138,13 @@ async def fetch_quote(symbol: str, client: YFinanceClientInterface) -> QuoteResp
     info = await client.get_info(symbol)
     info = _ensure_info_present(info, symbol)
 
+    # Additional guard: fail if info is empty or all fields are None
+    if not any(info.values()):
+        logger.warning("quote.fetch.empty_upstream_data", extra={"symbol": symbol})
+        raise HTTPException(status_code=502, detail="Upstream data is empty")
+
+    mapped = _map_quote(symbol, info)
+
     logger.info("quote.fetch.success", extra={"symbol": symbol})
-    return _map_quote(symbol, info)
+    return mapped
+


### PR DESCRIPTION
### Improved fetch_quote error handling and logging
---
#### Description:

This PR addresses three issues in the fetch_quote function in service.py:

- Missing required fields now include 'symbol' in the error.

- Previously, when upstream data was missing required fields, the raised HTTPException listed only the fields.

- Now the exception detail includes the symbol, e.g., "Missing required fields in upstream data for AAPL: current_price, open".

- This improves debugging and provides better context to clients.

- Guard against empty upstream data.

- Added a check after _ensure_info_present to handle upstream responses that are empty dicts or have all None values.

- Raises HTTPException(status_code=502, detail="Upstream data is empty").

- Ensures consistent handling of empty responses without silently returning incomplete data.

- Malformed numeric fields handling.

- Added **_raise_malformed_data** helper to consolidate numeric parsing failures.

- Raises HTTPException(status_code=502, detail="Malformed numeric data from upstream for {symbol}") when required numeric fields cannot be parsed.

- This prevents returning None or invalid values for price/volume fields.
---
#### Other changes:

- Updated logging to include symbol context for missing fields and malformed numbers.

- Added comprehensive async tests covering valid symbols, missing fields, malformed numbers, missing optional volume, and empty upstream data.

#### Result:

- Improves observability and error reporting for clients.

- Ensures QuoteResponse always contains valid data or raises appropriate HTTP errors.
---
Closes: #46
Closes: #47 
Closes: #48
