### PR TITLE
chore: bump fastapi and starlette dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,19 +8,19 @@ authors = [
 readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
-    "fastapi (>=0.116.1,<0.117.0)",
+    "fastapi (>=0.124.4,<0.125.0)",
     "yfinance (>=0.2.65,<0.3.0)",
     "uvicorn (>=0.35.0,<0.36.0)",
     "pydantic (>=2.11.7,<3.0.0)",
     "pandas (>=2.3.1,<3.0.0)",
     "prometheus-client (>=0.22.1,<0.23.0)",
-    "starlette (>=0.47.2,<0.48.0)",
+    "starlette (>=0.50.0,<0.51.0)",
     "httpx (>=0.28.1,<0.29.0)"
 ]
 package-mode = false
 
 [tool.poetry.group.docker.dependencies]
-uvloop = "^0.22.1"
+uvloop = {version = "^0.22.1", markers = "sys_platform == 'linux'"}
 httptools = "^0.7.1"
 
 [tool.poetry.group.dev.dependencies]

--- a/tests/features/test_historical.py
+++ b/tests/features/test_historical.py
@@ -70,5 +70,5 @@ async def test_historical_interval_valid(client: AsyncClient, interval: str):
 async def test_historical_interval_invalid(client: AsyncClient, interval: str):
     """Test invalid aggregation intervals for /historical endpoint."""
     resp = client.get("/historical/AAPL", params={"interval": interval})
-    assert resp.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY, f"Expected 422 for {interval}"
+    assert resp.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT, f"Expected 422 for {interval}"
     assert "interval" in resp.text


### PR DESCRIPTION
Bumps fastapi to >=0.24.4,<0.125.0 and starlette to >=0.50.0,<0.51.0

Why: 
- Pull in bug fixes, performance improvements, and upstream maintenance for FastAPI/Starlette.
