### PR TITLE
Add opt-in CORS support with configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ Relevant files:
 | `EARNINGS_CACHE_MAXSIZE` | Max entries for earnings cache | `128` | `EARNINGS_CACHE_MAXSIZE=256` |
 | `INFO_CACHE_TTL` | Cache TTL for company info (seconds) | `300` | `INFO_CACHE_TTL=300` |
 | `INFO_CACHE_MAXSIZE` | Max entries for info cache | `256` | `INFO_CACHE_MAXSIZE=512` |
+| `CORS_ENABLED` | Enable CORS | `False` | `CORS_ENABLED=True` |
+| `CORS_ALLOWED_ORIGINS` | Allowed origins (comma-separated list) | `*` (Any) | `CORS_ALLOWED_ORIGINS="https://example.org,https://www.example.org"` |
 
 ### Examples
 

--- a/app/main.py
+++ b/app/main.py
@@ -60,6 +60,17 @@ app = FastAPI(
     lifespan=lifespan,
 )
 
+settings = get_settings()
+if settings.cors_enabled:
+    from fastapi.middleware.cors import CORSMiddleware
+
+    app.add_middleware(
+        middleware_class=CORSMiddleware,
+        allow_origins=settings.cors_allowed_origins,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+
 # Unified logging + metrics middleware
 app.middleware("http")(http_metrics_middleware)
 

--- a/app/settings.py
+++ b/app/settings.py
@@ -16,7 +16,7 @@ class LogLevel(str, Enum):
 class Settings(BaseSettings):
     model_config = SettingsConfigDict(
         env_file=".env",
-        case_sensitive=True,
+        case_sensitive=False,
         validate_default=True,
         frozen=True,
     )
@@ -27,6 +27,13 @@ class Settings(BaseSettings):
     earnings_cache_maxsize: int = Field(128, env="EARNINGS_CACHE_MAXSIZE", ge=0)
     info_cache_ttl: int = Field(300, env="INFO_CACHE_TTL", ge=0)
     info_cache_maxsize: int = Field(256, env="INFO_CACHE_MAXSIZE", ge=0)
+
+    # CORS (Opt-in)
+    cors_enabled: bool = Field(False, env="CORS_ENABLED")
+    cors_allowed_origins: list[str] = Field(
+        default_factory=lambda: ["*"],
+        env="CORS_ALLOWED_ORIGINS",
+    )
 
     @field_validator("log_level", mode="before")
     def _upper(cls, v: str) -> str:


### PR DESCRIPTION
Introduce configuration options for enabling CORS and specifying allowed origins. This allows users to opt-in to CORS functionality as needed.