### PR TITLE
Refactor splits router to enforce API key dependency

### DIFF
--- a/app/features/splits/router.py
+++ b/app/features/splits/router.py
@@ -1,13 +1,18 @@
 from typing import Annotated
+
 from fastapi import APIRouter, Depends
+
 from app.clients.interface import YFinanceClientInterface
+from app.common.validation import SymbolParam
+from app.dependencies import get_splits_cache, get_yfinance_client
 from app.utils.cache.interface import CacheInterface
-from app.dependencies import get_yfinance_client, get_splits_cache
+
+from ...auth import check_api_key
 from .models import StockSplit
 from .service import get_splits
-from app.common.validation import SymbolParam
 
-router = APIRouter()
+router = APIRouter(dependencies=[Depends(check_api_key)])
+
 
 @router.get("/{symbol}", response_model=list[StockSplit])
 async def read_splits(


### PR DESCRIPTION
Organize imports and enforce API key dependency in the splits router to enhance security and maintainability.