### PR TITLE
Add readiness probe latency metric and Grafana panel

### DIFF
--- a/app/features/health/router.py
+++ b/app/features/health/router.py
@@ -9,7 +9,8 @@ from fastapi import APIRouter, Depends, HTTPException
 
 from ...clients.interface import YFinanceClientInterface
 from ...dependencies import get_yfinance_client
-
+import time
+from app.monitoring.metrics import YF_PROBE_LATENCY
 router = APIRouter()
 
 
@@ -46,10 +47,30 @@ async def get_health():
         },
     },
 )
-async def get_ready(client: Annotated[YFinanceClientInterface, Depends(get_yfinance_client)]):
+async def get_ready(
+    client: Annotated[YFinanceClientInterface, Depends(get_yfinance_client)]
+):
     """Readiness check endpoint to verify yfinance is reachable."""
-    if not await client.ping():
-        raise HTTPException(status_code=503, detail="Not ready")
-    return {"status": "ready"}
+
+    start = time.perf_counter()
+    outcome = "success"
+
+    try:
+        if not await client.ping():
+            outcome = "failure"
+            raise HTTPException(status_code=503, detail="Not ready")
+
+        return {"status": "ready"}
+
+    except Exception:
+        outcome = "failure"
+        raise
+
+    finally:
+        duration = time.perf_counter() - start
+        YF_PROBE_LATENCY.labels(
+            probe_type="readiness",
+            outcome=outcome,
+        ).observe(duration)
     # TODO(readiness): Replace ad-hoc ticker instantiation with lightweight probe
     # and short-lived cached readiness state to reduce load.

--- a/app/monitoring/metrics.py
+++ b/app/monitoring/metrics.py
@@ -66,6 +66,13 @@ YF_LATENCY = Histogram(
     ("operation",),
     buckets=(0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10),
 )
+
+YF_PROBE_LATENCY = Histogram(
+    "yf_probe_latency_seconds",
+    "Latency of readiness/liveness probes",
+    ("probe_type", "outcome"),
+    buckets=(0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1),
+)
 # TODO(metrics): Track separate histogram for upstream errors only for SLO burn rate analysis.
 
 

--- a/monitoring/grafana/dashboards/yfinance-dashboard.json
+++ b/monitoring/grafana/dashboards/yfinance-dashboard.json
@@ -318,6 +318,31 @@
                 },
                 "overrides": []
             }
-        }
+        },
+        {
+            "id": 9,
+            "type": "timeseries",
+            "title": "Readiness Probe Latency (s)",
+            "datasource": "Prometheus",
+            "gridPos": {
+              "h": 8,
+              "w": 24,
+              "x": 0,
+              "y": 64
+            },
+            "targets": [
+              {
+                "expr": "sum(rate(yf_probe_latency_seconds_sum[5m])) / sum(rate(yf_probe_latency_seconds_count[5m]))",
+                "legendFormat": "avg latency"
+              }
+            ],
+            "fieldConfig": {
+              "defaults": {
+                "unit": "s",
+                "decimals": 3
+              },
+              "overrides": []
+            }
+          }
     ]
 }


### PR DESCRIPTION
- Added Prometheus histogram `yf_probe_latency_seconds` to track readiness probe latency
- Instrumented /ready endpoint to record latency and outcome (success/failure)
- Ensured metric is recorded for both success and failure cases
- Added Grafana dashboard panel to visualize probe latency

This helps monitor upstream responsiveness separately from request latency. #73 