### PR TITLE
Add no-cache header support (#141)

### DIFF
--- a/app/features/earnings/router.py
+++ b/app/features/earnings/router.py
@@ -2,7 +2,7 @@
 
 from typing import Annotated, Literal
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, Query, Request
 
 from ...clients.interface import YFinanceClientInterface
 from ...common.validation import SymbolParam
@@ -50,6 +50,7 @@ router = APIRouter()
     },
 )
 async def get_earnings(
+    request: Request,
     symbol: SymbolParam,
     client: Annotated[YFinanceClientInterface, Depends(get_yfinance_client)],
     cache: Annotated[SnapshotCache | None, Depends(get_earnings_cache)] = None,
@@ -72,13 +73,22 @@ async def get_earnings(
     """
     cache_key = f"{symbol.upper()}:{frequency}"
 
-    # Use cache with get_or_set if cache is enabled
+    # read header
+    no_cache = request.headers.get("Cache-Control") == "no-cache"
+
+    # If no-cache → skip cache completely
+    if no_cache:
+        return await fetch_earnings(symbol, client, frequency)
+
+    # Normal flow (use cache)
     result = None
     if cache:
-        result = await cache.get_or_set(cache_key, fetch_earnings(symbol, client, frequency))
+        result = await cache.get_or_set(
+            cache_key, fetch_earnings(symbol, client, frequency)
+        )
 
     if result is not None:
         return result
 
-    # Fallback if cache is disabled or empty
+    # fallback
     return await fetch_earnings(symbol, client, frequency)

--- a/app/features/info/router.py
+++ b/app/features/info/router.py
@@ -5,7 +5,7 @@ Inline backlog notes for caching and access control.
 
 from typing import Annotated
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Request
 
 from ...clients.interface import YFinanceClientInterface
 from ...common.validation import SymbolParam
@@ -63,9 +63,14 @@ router = APIRouter()
     },
 )
 async def get_info(
+    request: Request,
     symbol: SymbolParam,
     client: Annotated[YFinanceClientInterface, Depends(get_yfinance_client)],
     info_cache: Annotated[CacheInterface, Depends(get_info_cache)],
 ) -> InfoResponse:
     """Get detailed information about a company for a given ticker symbol."""
+    # read header
+    no_cache = request.headers.get("Cache-Control") == "no-cache"
+    if no_cache:
+        return await fetch_info(symbol, client, None)
     return await fetch_info(symbol, client, info_cache)

--- a/app/features/news/router.py
+++ b/app/features/news/router.py
@@ -2,7 +2,7 @@
 
 from typing import Annotated, Literal
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, Query, Request
 
 from app.clients.interface import YFinanceClientInterface
 from app.common.validation import SymbolParam
@@ -173,6 +173,7 @@ TabAllowedValues = Literal["news", "press-releases", "all"]
     },
 )
 async def get_news(
+    request: Request,
     symbol: SymbolParam,
     count: Annotated[
         int,
@@ -186,6 +187,16 @@ async def get_news(
     client: YFinanceClientInterface = Depends(get_yfinance_client),
 ) -> NewsResponse:
     """Get news for a given ticker symbol."""
+    no_cache = request.headers.get("Cache-Control") == "no-cache"
+    if no_cache:
+        return await fetch_news(
+            symbol=symbol,
+            count=count,
+            tab=tab,
+            client=client,
+            news_cache=None,
+        )
+
     return await fetch_news(
         symbol=symbol,
         count=count,

--- a/app/features/snapshot/router.py
+++ b/app/features/snapshot/router.py
@@ -5,7 +5,7 @@ Provides the /snapshot/{symbol} endpoint for fetching combined info and quote da
 
 from typing import Annotated
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Request
 
 from ...clients.interface import YFinanceClientInterface
 from ...common.validation import SymbolParam
@@ -77,9 +77,13 @@ router = APIRouter()
     },
 )
 async def get_snapshot(
+    request: Request, 
     symbol: SymbolParam,
     client: Annotated[YFinanceClientInterface, Depends(get_yfinance_client)],
     info_cache: Annotated[CacheInterface, Depends(get_info_cache)],
 ) -> SnapshotResponse:
     """Get both company information and latest market quote for a ticker symbol."""
+    no_cache = request.headers.get("Cache-Control") == "no-cache"
+    if no_cache:
+        return await fetch_snapshot(symbol, client, None)
     return await fetch_snapshot(symbol, client, info_cache)

--- a/app/features/splits/router.py
+++ b/app/features/splits/router.py
@@ -1,6 +1,6 @@
 from typing import Annotated
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Request
 
 from app.clients.interface import YFinanceClientInterface
 from app.common.validation import SymbolParam
@@ -15,8 +15,12 @@ router = APIRouter()
 
 @router.get("/{symbol}", response_model=list[StockSplit])
 async def read_splits(
+    request: Request,
     symbol: SymbolParam,
     client: Annotated[YFinanceClientInterface, Depends(get_yfinance_client)] = None,
     cache: Annotated[CacheInterface, Depends(get_splits_cache)] = None,
 ):
+    no_cache = request.headers.get("Cache-Control") == "no-cache"
+    if no_cache:
+        return await get_splits(symbol.upper(), client, None)
     return await get_splits(symbol.upper(), client, cache)


### PR DESCRIPTION
- Added support for Cache-Control: no-cache header in cached endpoints

Changes:
- Earnings: bypass cache when header is present
- Info: disable cache by passing None to service
- News: disable cache by passing None to service
- Snapshot: disable cache by passing None to service
- Splits: disable cache by passing None to service

This allows clients to force fresh data fetch instead of using cached responses. #141 