### PR TITLE
refactor(tests): organize quote tests into feature-specific directory

### DIFF
--- a/app/features/earnings/router.py
+++ b/app/features/earnings/router.py
@@ -19,7 +19,10 @@ router = APIRouter()
     response_model=EarningsResponse,
     response_model_exclude_none=True,
     summary="Get earnings history for a symbol",
-    description="Returns normalized earnings history (quarterly or annual) with reported/estimated EPS, revenue, and surprise data.",
+    description=(
+        "Returns normalized earnings history (quarterly or annual) "
+        "with reported/estimated EPS, revenue, and surprise data."
+    ),
     operation_id="getEarningsBySymbol",
     responses={
         200: {

--- a/app/features/quote/conftest.py
+++ b/app/features/quote/conftest.py
@@ -1,0 +1,31 @@
+from unittest.mock import AsyncMock
+
+import pytest
+
+
+@pytest.fixture(scope="function")
+def quote_payload_factory():
+    base = {
+        "symbol": "AAPL",
+        "current_price": 150.0,
+        "previous_close": 148.0,
+        "open_price": 149.0,
+        "high": 151.0,
+        "low": 147.5,
+        "volume": 1000000,
+    }
+
+    def _factory(**overrides):
+        payload = base.copy()
+        payload.update(overrides)
+        return payload
+
+    return _factory
+
+
+@pytest.fixture(scope="function")
+def failing_cache():
+    c = AsyncMock()
+    c.get.return_value = None
+    c.set.side_effect = Exception("Cache failure")
+    return c

--- a/tests/unit/features/quote/test_quote.py
+++ b/tests/unit/features/quote/test_quote.py
@@ -1,0 +1,134 @@
+"""Tests for the /quote endpoint."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import HTTPException
+
+from app.features.quote.service import QuoteResponse, fetch_quote
+
+VALID_SYMBOL = "AAPL"
+INDEX_SYMBOL = "^GSPC"
+INVALID_SYMBOL = "!!!"
+NOT_FOUND_SYMBOL = "ZZZZZZZZZZ"
+
+
+def test_quote_valid_symbol(client, mock_yfinance_client):
+    """Test case for a valid symbol."""
+    mock_yfinance_client.get_info.return_value = {
+        "symbol": VALID_SYMBOL,
+        "regularMarketPrice": 150.0,
+        "regularMarketPreviousClose": 148.0,
+        "regularMarketOpen": 149.0,
+        "regularMarketDayHigh": 151.0,
+        "regularMarketDayLow": 147.5,
+        "regularMarketVolume": 1000000,
+    }
+    response = client.get(f"/quote/{VALID_SYMBOL}")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["symbol"] == VALID_SYMBOL
+    assert data["current_price"] == 150.0
+
+
+def test_quote_index_symbol_with_caret(client, mock_yfinance_client):
+    """Index symbols with '^' should pass path validation."""
+    mock_yfinance_client.get_info.return_value = {
+        "symbol": INDEX_SYMBOL,
+        "regularMarketPrice": 6000.0,
+        "regularMarketPreviousClose": 5980.0,
+        "regularMarketOpen": 5990.0,
+        "regularMarketDayHigh": 6010.0,
+        "regularMarketDayLow": 5970.0,
+        "regularMarketVolume": 123456,
+    }
+    response = client.get(f"/quote/{INDEX_SYMBOL}")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["symbol"] == INDEX_SYMBOL
+
+
+def test_quote_invalid_symbol(client):
+    """Test case for an invalid symbol format."""
+    response = client.get(f"/quote/{INVALID_SYMBOL}")
+    assert response.status_code == 422
+    body = response.json()
+    assert "detail" in body and isinstance(body["detail"], list)
+
+
+def test_quote_not_found_symbol(client, mock_yfinance_client):
+    """Test case for a symbol not found."""
+    mock_yfinance_client.get_info.side_effect = HTTPException(
+        status_code=404, detail=f"No data for {NOT_FOUND_SYMBOL}"
+    )
+    response = client.get(f"/quote/{NOT_FOUND_SYMBOL}")
+    assert response.status_code == 404
+    assert "No data for" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_fetch_quote_upstream_none():
+    """Upstream returns None -> should raise 502."""
+    client = AsyncMock()
+    client.get_info.return_value = None
+    with pytest.raises(HTTPException) as exc:
+        await fetch_quote("AAPL", client)
+    assert exc.value.status_code == 502
+    assert "No data from upstream" in exc.value.detail
+
+
+@pytest.mark.asyncio
+async def test_fetch_quote_upstream_empty():
+    """Upstream returns empty dict -> should raise 502."""
+    client = AsyncMock()
+    client.get_info.return_value = {}
+    with pytest.raises(HTTPException) as exc:
+        await fetch_quote("AAPL", client)
+    assert exc.value.status_code == 502
+    assert "No data from upstream" in exc.value.detail
+
+
+@pytest.mark.asyncio
+async def test_fetch_quote_missing_required_fields():
+    """Upstream missing a required field -> should raise 502 with symbol."""
+    client = AsyncMock()
+    client.get_info.return_value = {"regularMarketPrice": 100.0}  # missing others
+    with pytest.raises(HTTPException) as exc:
+        await fetch_quote("AAPL", client)
+    assert exc.value.status_code == 502
+    assert "Malformed quote data" in exc.value.detail
+    assert "AAPL" in exc.value.detail
+
+
+@pytest.mark.asyncio
+async def test_fetch_quote_malformed_numbers():
+    """Upstream has malformed numeric fields -> should raise 502."""
+    client = AsyncMock()
+    client.get_info.return_value = {
+        "regularMarketPrice": "not-a-number",  # invalid
+        "regularMarketPreviousClose": 95.0,
+        "regularMarketOpen": 98.0,
+        "regularMarketDayHigh": 102.0,
+        "regularMarketDayLow": 94.0,
+    }
+    with pytest.raises(HTTPException) as exc:
+        await fetch_quote("AAPL", client)
+    assert exc.value.status_code == 502
+    assert "Malformed quote data" in exc.value.detail
+
+
+@pytest.mark.asyncio
+async def test_fetch_quote_missing_volume():
+    """Upstream missing optional volume -> should succeed, volume None."""
+    client = AsyncMock()
+    client.get_info.return_value = {
+        "regularMarketPrice": 100.0,
+        "regularMarketPreviousClose": 95.0,
+        "regularMarketOpen": 98.0,
+        "regularMarketDayHigh": 102.0,
+        "regularMarketDayLow": 94.0,
+        # volume missing
+    }
+    result = await fetch_quote("AAPL", client)
+    assert isinstance(result, QuoteResponse)
+    assert result.volume is None

--- a/tests/unit/features/quote/test_quote_bulk.py
+++ b/tests/unit/features/quote/test_quote_bulk.py
@@ -1,0 +1,76 @@
+"""Tests for the bulk /quote endpoint.
+
+Covers successful multi-symbol fetch and partial-failure behavior.
+"""
+
+from fastapi import HTTPException
+
+VALID_A = "AAPL"
+VALID_B = "MSFT"
+NOT_FOUND = "ZZZZZZ"
+
+
+def test_quote_bulk_success(client, mock_yfinance_client):
+    """Both symbols return valid data."""
+    mapping = {
+        VALID_A: {
+            "symbol": VALID_A,
+            "regularMarketPrice": 150.0,
+            "regularMarketPreviousClose": 148.0,
+            "regularMarketOpen": 149.0,
+            "regularMarketDayHigh": 151.0,
+            "regularMarketDayLow": 147.5,
+            "regularMarketVolume": 1000000,
+        },
+        VALID_B: {
+            "symbol": VALID_B,
+            "regularMarketPrice": 300.0,
+            "regularMarketPreviousClose": 298.0,
+            "regularMarketOpen": 299.0,
+            "regularMarketDayHigh": 301.0,
+            "regularMarketDayLow": 297.5,
+            "regularMarketVolume": 2000000,
+        },
+    }
+
+    def _side(sym):
+        return mapping[sym]
+
+    mock_yfinance_client.get_info.side_effect = _side
+
+    response = client.get(f"/quote?symbols={VALID_A},{VALID_B}")
+    assert response.status_code == 200
+    data = response.json()
+    assert VALID_A in data and VALID_B in data
+    assert data[VALID_A]["current_price"] == 150.0
+    assert data[VALID_B]["current_price"] == 300.0
+
+
+def test_quote_bulk_partial_failure(client, mock_yfinance_client):
+    """One symbol succeeds, one returns HTTPException -> reported per-symbol."""
+
+    def _side(sym):
+        if sym == VALID_A:
+            return {
+                "symbol": VALID_A,
+                "regularMarketPrice": 150.0,
+                "regularMarketPreviousClose": 148.0,
+                "regularMarketOpen": 149.0,
+                "regularMarketDayHigh": 151.0,
+                "regularMarketDayLow": 147.5,
+            }
+        raise HTTPException(status_code=404, detail=f"No data for {sym}")
+
+    mock_yfinance_client.get_info.side_effect = _side
+
+    response = client.get(f"/quote?symbols={VALID_A},{NOT_FOUND}")
+    assert response.status_code == 200
+    data = response.json()
+    assert VALID_A in data and NOT_FOUND in data
+    # success entry is a quote
+    assert isinstance(data[VALID_A], dict)
+    assert data[VALID_A]["current_price"] == 150.0
+    # failure entry contains error and status_code
+    assert isinstance(data[NOT_FOUND], dict)
+    assert "error" in data[NOT_FOUND]
+    assert data[NOT_FOUND]["status_code"] == 404


### PR DESCRIPTION

Moved:
test_quote.py
test_quote_bulk.py
into tests/unit/features/quote/
Added conftest.py for quote-specific fixtures
Aligned structure with existing feature test directories (e.g., info, news)

Testing
Ran full test suite:  163 passed, 1 skipped