### PR TITLE
[PATCH] HTTP 502 for mutual funds missing intraday data

### DIFF
--- a/app/features/quote/models.py
+++ b/app/features/quote/models.py
@@ -38,22 +38,22 @@ class QuoteResponse(BaseModel):
         examples=[148.0, 2790.0],
         validation_alias=AliasChoices("regularMarketPreviousClose", "previousClose"),
     )
-    open_price: float = Field(
-        ...,
+    open_price: float | None = Field(
+        None,
         description="Opening price",
-        examples=[149.0, 2795.0],
+        examples=[149.0, 2795.0, None],
         validation_alias=AliasChoices("regularMarketOpen", "open"),
     )
-    high: float = Field(
-        ...,
+    high: float | None = Field(
+        None,
         description="Highest price of the day",
-        examples=[151.0, 2805.0],
+        examples=[151.0, 2805.0, None],
         validation_alias=AliasChoices("regularMarketDayHigh", "dayHigh"),
     )
-    low: float = Field(
-        ...,
+    low: float | None = Field(
+        None,
         description="Lowest price of the day",
-        examples=[147.5, 2785.0],
+        examples=[147.5, 2785.0, None],
         validation_alias=AliasChoices("regularMarketDayLow", "dayLow"),
     )
     volume: int | None = Field(
@@ -71,9 +71,9 @@ class QuoteResponse(BaseModel):
 
     @field_validator("current_price", "previous_close", "open_price", "high", "low")
     @classmethod
-    def non_negative(cls, v: float) -> float:
+    def non_negative(cls, v: float | None) -> float | None:
         """Ensure price fields are non-negative."""
-        if v < 0:
+        if v is not None and v < 0:
             raise ValueError("must be non-negative")
         return v
 

--- a/tests/unit/features/quote/test_quote.py
+++ b/tests/unit/features/quote/test_quote.py
@@ -4,14 +4,48 @@ from unittest.mock import AsyncMock
 
 import pytest
 from fastapi import HTTPException
+from fastapi.testclient import TestClient
 
 from app.features.quote.service import QuoteResponse, fetch_quote
+from app.main import app
+
 
 VALID_SYMBOL = "AAPL"
 INDEX_SYMBOL = "^GSPC"
 INVALID_SYMBOL = "!!!"
 NOT_FOUND_SYMBOL = "ZZZZZZZZZZ"
 
+app_client = TestClient(app)
+
+def test_mutual_fund_quote():
+    response = app_client.get("/quote/0P00017XE0.SW")
+    assert response.status_code == 200
+
+def test_handles_missing_price_field(monkeypatch):
+    async def mock_fetch_quote(symbol: str, client):
+        # Return data missing open/high/low fields - should succeed with nulls
+        return QuoteResponse(
+            symbol=symbol,
+            current_price=100.0,
+            previous_close=99.0,
+            open_price=None,
+            high=None,
+            low=None,
+            volume=None,
+        )
+
+    monkeypatch.setattr("app.features.quote.router.fetch_quote", mock_fetch_quote)
+
+    response = app_client.get("/quote/FAKE")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["current_price"] == 100.0
+    # open_price is None, so it's excluded from response (response_model_exclude_none=True)
+    assert "open_price" not in data
+
+def test_quote_never_500s():
+    response = app_client.get("/quote/0P00017XE0.SW")
+    assert response.status_code != 500
 
 def test_quote_valid_symbol(client, mock_yfinance_client):
     """Test case for a valid symbol."""

--- a/tests/unit/features/quote/test_quote.py
+++ b/tests/unit/features/quote/test_quote.py
@@ -17,9 +17,34 @@ NOT_FOUND_SYMBOL = "ZZZZZZZZZZ"
 
 app_client = TestClient(app)
 
-def test_mutual_fund_quote():
+def test_mutual_fund_quote(monkeypatch):
+    """Test that instruments missing intraday data (like mutual funds) return 200."""
+    # Simulate Yahoo Finance response for a mutual fund - missing open/high/low/volume
+    async def mock_fetch_quote(symbol: str, client):
+        return QuoteResponse(
+            symbol=symbol,
+            current_price=189.03,
+            previous_close=188.66,
+            open_price=None,
+            high=None,
+            low=None,
+            volume=None,
+        )
+
+    monkeypatch.setattr("app.features.quote.router.fetch_quote", mock_fetch_quote)
+
     response = app_client.get("/quote/0P00017XE0.SW")
     assert response.status_code == 200
+    data = response.json()
+    assert data["symbol"] == "0P00017XE0.SW"
+    assert data["current_price"] == 189.03
+    assert data["previous_close"] == 188.66
+    # Optional fields are None and excluded from response
+    assert "open_price" not in data
+    assert "high" not in data
+    assert "low" not in data
+    assert "volume" not in data
+
 
 def test_handles_missing_price_field(monkeypatch):
     async def mock_fetch_quote(symbol: str, client):
@@ -43,9 +68,6 @@ def test_handles_missing_price_field(monkeypatch):
     # open_price is None, so it's excluded from response (response_model_exclude_none=True)
     assert "open_price" not in data
 
-def test_quote_never_500s():
-    response = app_client.get("/quote/0P00017XE0.SW")
-    assert response.status_code != 500
 
 def test_quote_valid_symbol(client, mock_yfinance_client):
     """Test case for a valid symbol."""


### PR DESCRIPTION
### Problem
The `/quote/0P00017XE0.SW` endpoint returned HTTP 502 "Malformed quote data 
from upstream" for the PostFinance Pension ESG 75 Fund (and likely other 
mutual funds).

### Root Cause
The `QuoteResponse` model required `open_price`, `high`, and `low` as mandatory 
fields, but mutual funds don't provide intraday trading data from Yahoo Finance. 
When these fields were missing, Pydantic validation failed.

### Solution
Made `open_price`, `high`, and `low` optional fields (default `None`), matching 
the existing pattern for `volume`. Updated the `non_negative` validator to 
handle `None` values.

### Files Changed
- `app/features/quote/models.py` — Made fields optional
- `tests/unit/features/quote/test_quote.py` — Added generalised regression tests

### Tests Added
- `test_mutual_fund_quote` — Tests instruments missing intraday data (mock-based)
- `test_handles_missing_price_field` — Tests missing open/high/low fields

Closes: #170