### PR TITLE
  Align API key auth defaults with documented unprotected endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Relevant files:
 | `SPLITS_CACHE_TTL` |Time-to-live (in seconds) for the stock splits cache| `3600` | `SPLITS_CACHE_TTL=1800` |
 | `API_KEY_ENABLED` | Enable API key authentication | `False` | `API_KEY_ENABLED=True` |
 | `API_KEY` | API key for authentication (required if enabled) | `""` | `API_KEY=your-secret-key-here` |
+| `API_KEY_UNPROTECTED_ENDPOINTS` | First path segments that bypass API key auth | `health,ready,metrics,docs,redoc,openapi.json` | `API_KEY_UNPROTECTED_ENDPOINTS="health,metrics"` |
 
 ### API Key Authentication
 
@@ -118,17 +119,21 @@ API_KEY=your-secret-key-here
 # Include API key in X-API-Key header
 curl -H "X-API-Key: your-secret-key-here" http://localhost:8000/quote/AAPL
 ```
-**Protected endpoints:**
-- `/quote/*` - Stock quotes
-- `/historical/*` - Historical data
-- `/info/*` - Company information
-- `/snapshot/*` - Combined snapshots
-- `/earnings/*` - Earnings data
+**Protected endpoints by default:**
+- all application endpoints except the unprotected list below
+- this includes `/quote/*`, `/historical/*`, `/info/*`, `/snapshot/*`, `/earnings/*`, `/news/*`, and `/splits/*`
 
 **Unprotected endpoints:**
 - `/health`, `/ready` - Health checks
 - `/metrics` - Prometheus metrics
-- `/docs`, `/redoc` - API documentation
+- `/docs`, `/redoc`, `/openapi.json` - API documentation routes
+
+`API_KEY_UNPROTECTED_ENDPOINTS` matches the first request path segment without a
+leading slash. Examples:
+- `/quote/AAPL` -> `quote`
+- `/docs` -> `docs`
+- `/openapi.json` -> `openapi.json`
+- `/` -> `root`
 
 ### Examples
 
@@ -330,4 +335,3 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind welcome!
-

--- a/app/auth.py
+++ b/app/auth.py
@@ -11,6 +11,14 @@ from app.settings import Settings
 logger = getLogger(__name__)
 
 
+def _request_endpoint_key(path: str) -> str:
+    """Map a request path to the config key used by API_KEY_UNPROTECTED_ENDPOINTS."""
+    stripped = path.lstrip("/")
+    if not stripped:
+        return "root"
+    return stripped.split("/", 1)[0]
+
+
 async def check_api_key(
     request: Request,
     settings: Annotated[Settings, Depends(get_settings)],
@@ -28,7 +36,7 @@ async def check_api_key(
 
     """
     # If endpoint is not protected, allow request
-    endpoint = request.url.path.split("/")[1] if len(request.url.path.split("/")) > 1 else "root"
+    endpoint = _request_endpoint_key(request.url.path)
     if endpoint in settings.api_key_unprotected_endpoints:
         return
 

--- a/app/settings.py
+++ b/app/settings.py
@@ -71,10 +71,10 @@ class Settings(BaseSettings):
     api_key_enabled: bool = Field(False, validation_alias="API_KEY_ENABLED")
     api_key: str = Field("", validation_alias="API_KEY")
     # Endpoints that do not require API key authentication
-    # Provide endpoint paths without leading slash, e.g. "info", "quote", "historical"
-    # For root endpoint, use "root". Wildcards are not supported.
+    # Provide the first request path segment without a leading slash, e.g. "info" for
+    # /info/AAPL or "docs" for /docs. For root, use "root". Wildcards are not supported.
     api_key_unprotected_endpoints: list[str] = Field(
-        default_factory=lambda: ["health"],
+        default_factory=lambda: ["health", "ready", "metrics", "docs", "redoc", "openapi.json"],
         validation_alias="API_KEY_UNPROTECTED_ENDPOINTS",
     )
 

--- a/tests/integration/test_api_key_auth.py
+++ b/tests/integration/test_api_key_auth.py
@@ -32,6 +32,11 @@ def auth_app() -> FastAPI:
     auth_app.include_router(snapshot_router, prefix="/snapshot", tags=["snapshot"])
     auth_app.include_router(earnings_router, prefix="/earnings", tags=["earnings"])
     auth_app.include_router(health_router, tags=["health"])
+
+    @auth_app.get("/metrics")
+    async def metrics():
+        return {"status": "ok"}
+
     return auth_app
 
 
@@ -198,3 +203,22 @@ async def test_unprotected_endpoints(auth_app: FastAPI):
 
         resp = await client.get("/earnings/AAPL?frequency=quarterly", headers=headers)
         assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_default_unprotected_endpoints_match_documentation(auth_app: FastAPI):
+    """Default auth config should allow documented health, metrics, and docs routes."""
+    test_settings = Settings(api_key="valid-test-key")
+
+    auth_app.dependency_overrides[get_yfinance_client] = lambda: FakeYFinanceClient()
+    auth_app.dependency_overrides[get_settings] = lambda: test_settings
+
+    transport = httpx.ASGITransport(app=auth_app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        for path in ("/health", "/ready", "/metrics", "/docs", "/redoc", "/openapi.json"):
+            response = await client.get(path)
+            assert response.status_code == 200, path
+
+        protected = await client.get("/quote/AAPL")
+        assert protected.status_code == 401


### PR DESCRIPTION
 This PR aligns the default API key authentication behavior with the routes documented as unprotected in the README.
Fixes #182 
  ## Changes

  - update the default API_KEY_UNPROTECTED_ENDPOINTS value to match the documented unprotected routes
  - clarify API key path matching by extracting the request-path-to-config mapping into app/auth.py
  - document how API_KEY_UNPROTECTED_ENDPOINTS maps to request paths
  - clarify that protected routes include endpoints like /news/* and /splits/* unless explicitly exempted
  - add integration coverage for:
      - /health
      - /ready
      - /metrics
      - /docs
      - /redoc
      - /openapi.json

  ## Verification

  - python -m pytest tests\unit -q
  - python -m pytest tests\integration -q

  ## Notes

  - matching is based on the first path segment without a leading slash
  - for example:
      - /quote/AAPL -> quote
      - /docs -> docs
      - /openapi.json -> openapi.json
      - / -> root
