### PR TITLE
Refactor caching logic and add symbol normalization helpers

### DIFF
--- a/app/features/info/service.py
+++ b/app/features/info/service.py
@@ -7,6 +7,7 @@ from typing import Any, Mapping
 
 from ...clients.interface import YFinanceClientInterface
 from ...utils.cache.interface import CacheInterface
+from ...utils.helpers import fetch_with_cache, normalize_symbol
 from ...utils.logger import logger
 from .models import InfoResponse
 
@@ -25,25 +26,19 @@ async def fetch_info(
         InfoResponse: The information response for the given symbol.
 
     """
-    symbol = symbol.strip().upper()
+    symbol = normalize_symbol(symbol)
     logger.info("info.fetch.start", extra={"symbol": symbol})
 
-    if info_cache:
-        cached = await info_cache.get(symbol)
-        if cached is not None:
-            logger.info("info.fetch.cache.hit", extra={"symbol": symbol})
-            return cached
-
-    info: Mapping[str, Any] = await client.get_info(symbol)
-
-    logger.info("info.fetch.success", extra={"symbol": symbol})
-
-    result = InfoResponse.model_validate({"symbol": symbol, **info})
+    async def _fetch_and_validate():
+        info: Mapping[str, Any] = await client.get_info(symbol)
+        logger.info("info.fetch.success", extra={"symbol": symbol})
+        return InfoResponse.model_validate({"symbol": symbol, **info})
 
     if info_cache:
-        try:
-            await info_cache.set(symbol, result)
-        except Exception:
-            logger.exception("info.set.cache.failed", extra={"symbol": symbol})
+        result = await fetch_with_cache(
+            symbol, info_cache, _fetch_and_validate, on_set_failed_event="info.set.cache.failed"
+        )
+    else:
+        result = await _fetch_and_validate()
 
     return result

--- a/app/features/news/service.py
+++ b/app/features/news/service.py
@@ -4,6 +4,7 @@ from app.clients.interface import YFinanceClientInterface
 from app.features.news.models import NewsResponse
 from app.utils.cache.news_cache import Key, NewsCache
 
+from ...utils.helpers import normalize_symbol
 from ...utils.logger import logger
 
 
@@ -34,13 +35,15 @@ async def fetch_news(
     if tab == "press-releases":
         tab = "press releases"
 
+    # Normalize symbol for cache and client calls
+    symbol = normalize_symbol(symbol)
+
     if news_cache:
         cached = await news_cache.get(Key(symbol=symbol, news_type=tab), count)
         if cached is not None:
             logger.info("news.fetch.cache.hit", extra={"symbol": symbol, "tab": tab})
             return NewsResponse(news=cached)
 
-    symbol = symbol.strip().upper()
     news = await client.get_news(symbol=symbol, count=count, tab=tab)
     result = NewsResponse.model_validate({"news": news})
 

--- a/app/features/snapshot/service.py
+++ b/app/features/snapshot/service.py
@@ -12,6 +12,7 @@ import asyncio
 
 from ...clients.interface import YFinanceClientInterface
 from ...utils.cache.interface import CacheInterface
+from ...utils.helpers import normalize_symbol
 from ...utils.logger import logger
 from ..info.service import fetch_info
 from ..quote.service import fetch_quote
@@ -35,7 +36,7 @@ async def fetch_snapshot(
         HTTPException: 400 for empty symbol, 502 if either info or quote fetch fails.
 
     """
-    symbol = symbol.upper().strip()
+    symbol = normalize_symbol(symbol)
     logger.info("snapshot.fetch.start", extra={"symbol": symbol})
 
     # Fetch info (possibly cached) and quote (always fresh) concurrently.

--- a/app/utils/helpers.py
+++ b/app/utils/helpers.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from typing import Any, Awaitable, Callable, Optional
+
+from .logger import logger
+
+
+def normalize_symbol(symbol: Optional[str]) -> str:
+    """Normalize a stock symbol: strip whitespace and uppercase.
+
+    Returns an empty string for falsy inputs.
+    """
+    if not symbol:
+        return ""
+    return symbol.strip().upper()
+
+
+async def fetch_with_cache(
+    key: str,
+    cache: object | None,
+    fetcher: Callable[[], Awaitable[Any]],
+    ttl: Optional[int] = None,
+    on_set_failed_event: Optional[str] = None,
+) -> Any:
+    """Fetch a value using `fetcher` and populate `cache` on miss.
+
+    - `cache` is expected to implement async `get(key)` and `set(key, value)`.
+    - If `ttl` is provided and the cache exposes a `set_with_ttl`, it will be used.
+    - Exceptions from cache operations are logged but do not fail the fetch.
+
+    Returns the cached or fetched value.
+    """
+    if cache:
+        try:
+            cached = await cache.get(key)
+            if cached is not None:
+                logger.info("helpers.cache.hit", extra={"key": key})
+                return cached
+        except Exception:
+            logger.exception("helpers.cache.get.failed", extra={"key": key})
+
+    # Miss: call fetcher
+    result = await fetcher()
+
+    if cache:
+        try:
+            # Prefer a ttl-aware setter if available
+            if ttl is not None and hasattr(cache, "set_with_ttl"):
+                await cache.set_with_ttl(key, result, ttl)
+            else:
+                await cache.set(key, result)
+        except Exception:
+            logger.exception("helpers.cache.set.failed", extra={"key": key})
+            if on_set_failed_event:
+                logger.exception(on_set_failed_event, extra={"key": key})
+
+    return result

--- a/tests/unit/utils/test_helpers.py
+++ b/tests/unit/utils/test_helpers.py
@@ -1,0 +1,75 @@
+import pytest
+
+from app.utils.helpers import fetch_with_cache, normalize_symbol
+
+
+class InMemoryCache:
+    def __init__(self):
+        self.store = {}
+
+    async def get(self, key):
+        return self.store.get(key)
+
+    async def set(self, key, value):
+        self.store[key] = value
+
+
+def test_normalize_symbol_basic():
+    assert normalize_symbol(None) == ""
+    assert normalize_symbol("") == ""
+    assert normalize_symbol(" aapl ") == "AAPL"
+    assert normalize_symbol(" ApPl ") == "APPL"
+
+
+@pytest.mark.asyncio
+async def test_fetch_with_cache_miss_and_set():
+    cache = InMemoryCache()
+
+    async def fetcher():
+        return {"x": 1}
+
+    res = await fetch_with_cache("k", cache, fetcher)
+    assert res == {"x": 1}
+    assert await cache.get("k") == {"x": 1}
+
+
+@pytest.mark.asyncio
+async def test_fetch_with_cache_hit():
+    cache = InMemoryCache()
+    await cache.set("k", 42)
+
+    called = False
+
+    async def fetcher():
+        nonlocal called
+        called = True
+        return 0
+
+    res = await fetch_with_cache("k", cache, fetcher)
+    assert res == 42
+    assert not called
+
+
+@pytest.mark.asyncio
+async def test_fetch_with_cache_fetcher_exception():
+    cache = InMemoryCache()
+
+    async def fetcher():
+        raise ValueError("boom")
+
+    with pytest.raises(ValueError):
+        await fetch_with_cache("k", cache, fetcher)
+
+    assert await cache.get("k") is None
+
+
+@pytest.mark.asyncio
+async def test_fetch_with_cache_ttl_param_unused():
+    cache = InMemoryCache()
+
+    async def fetcher():
+        return "v"
+
+    res = await fetch_with_cache("k2", cache, fetcher, ttl=5)
+    assert res == "v"
+    assert await cache.get("k2") == "v"

--- a/tests/unit/utils/test_helpers.py
+++ b/tests/unit/utils/test_helpers.py
@@ -73,3 +73,31 @@ async def test_fetch_with_cache_ttl_param_unused():
     res = await fetch_with_cache("k2", cache, fetcher, ttl=5)
     assert res == "v"
     assert await cache.get("k2") == "v"
+
+
+@pytest.mark.asyncio
+async def test_fetch_with_cache_uses_set_with_ttl():
+    class TTLCacheStub:
+        def __init__(self):
+            self.store = {}
+            self.called = False
+            self.args = None
+
+        async def get(self, key):
+            return self.store.get(key)
+
+        async def set_with_ttl(self, key, value, ttl):
+            self.called = True
+            self.args = (key, value, ttl)
+            self.store[key] = value
+
+    cache = TTLCacheStub()
+
+    async def fetcher():
+        return "ttl-value"
+
+    res = await fetch_with_cache("kt", cache, fetcher, ttl=123)
+    assert res == "ttl-value"
+    assert cache.called
+    assert cache.args == ("kt", "ttl-value", 123)
+    assert await cache.get("kt") == "ttl-value"


### PR DESCRIPTION
This pull request introduces a new `helpers` module to centralize symbol normalization and cache fetch logic, and refactors the `info`, `news`, and `snapshot` services to use these helpers. This improves code reuse, consistency, and reliability across the codebase. Additionally, comprehensive unit tests are added for the new helpers.

**Core utility additions:**

* Added `normalize_symbol` and `fetch_with_cache` utility functions in `app/utils/helpers.py`, providing standardized symbol normalization and a robust cache-fetch pattern with logging and TTL support.

**Service refactoring for consistency and maintainability:**

* Refactored `fetch_info` in `app/features/info/service.py` to use `normalize_symbol` for symbol handling and `fetch_with_cache` for cache interaction, replacing custom cache logic. [[1]](diffhunk://#diff-527951dd8d69475a39217778bc0366497e79162cb743d0da1b8d151c226fe66eR10) [[2]](diffhunk://#diff-527951dd8d69475a39217778bc0366497e79162cb743d0da1b8d151c226fe66eL28-R42)
* Updated `fetch_news` in `app/features/news/service.py` to use `normalize_symbol` for consistent symbol formatting before cache and client operations. [[1]](diffhunk://#diff-e25a1a77443992ffea399c57cefe307d5b71c4fd7cdfe9203190e5f3cf152c04R7) [[2]](diffhunk://#diff-e25a1a77443992ffea399c57cefe307d5b71c4fd7cdfe9203190e5f3cf152c04R38-L43)
* Modified `fetch_snapshot` in `app/features/snapshot/service.py` to normalize symbols using the new helper. [[1]](diffhunk://#diff-a43a186066ac178f7934745d371b96ab46e3a343e167d3591039086a9c83cd87R15) [[2]](diffhunk://#diff-a43a186066ac178f7934745d371b96ab46e3a343e167d3591039086a9c83cd87L38-R39)

**Testing improvements:**

* Added unit tests for `normalize_symbol` and `fetch_with_cache` in `tests/unit/utils/test_helpers.py`, covering cache hits, misses, TTL, and error handling.