### PR TITLE
Improve caching keys for Poetry and pip in CI workflow

### DIFF
--- a/.github/actions/setup-python-deps/action.yml
+++ b/.github/actions/setup-python-deps/action.yml
@@ -36,7 +36,7 @@ runs:
         pip-${{ runner.os }}-py${{ inputs.python_version }}-
 
   - name: Install Poetry
-    run: pip install --no-cache-dir poetry || { echo "Poetry install failed"; exit 1; }
+    run: pip install poetry || { echo "Poetry install failed"; exit 1; }
     shell: bash
 
   - name: Configure Poetry

--- a/.github/actions/setup-python-deps/action.yml
+++ b/.github/actions/setup-python-deps/action.yml
@@ -23,9 +23,17 @@ runs:
     uses: actions/cache@v4
     with:
       path: ~/.cache/pypoetry
-      key: pip-${{ runner.os }}-${{ hashFiles('**/poetry.lock', '**/pyproject.toml') }}
+      key: poetry-${{ runner.os }}-py${{ inputs.python_version }}-${{ hashFiles('**/poetry.lock', '**/pyproject.toml') }}
       restore-keys: |
-        pip-${{ runner.os }}-
+        poetry-${{ runner.os }}-py${{ inputs.python_version }}-
+
+  - name: Cache pip
+    uses: actions/cache@v4
+    with:
+      path: ~/.cache/pip
+      key: pip-${{ runner.os }}-py${{ inputs.python_version }}-${{ hashFiles('**/poetry.lock', '**/pyproject.toml') }}
+      restore-keys: |
+        pip-${{ runner.os }}-py${{ inputs.python_version }}-
 
   - name: Install Poetry
     run: pip install --no-cache-dir poetry || { echo "Poetry install failed"; exit 1; }
@@ -43,6 +51,13 @@ runs:
   - name: Install Dev Dependencies
     if: ${{ inputs.development }}
     run: poetry install --no-root --with dev || { echo "Dev dependency install failed"; exit 1; }
+    shell: bash
+
+  - name: Report cache sizes
+    if: always()
+    run: |
+      echo "Poetry cache:"; du -sh ~/.cache/pypoetry || true
+      echo "pip cache:"; du -sh ~/.cache/pip || true
     shell: bash
 outputs:
   python_version:


### PR DESCRIPTION
This pull request updates the caching strategy and adds cache size reporting to the `setup-python-deps` GitHub Action. The main improvements are more precise cache keys for both Poetry and pip, the addition of a separate pip cache step, and a new step to report cache sizes for better visibility.

**Caching improvements:**

* Updated the Poetry cache key to include the Python version and changed its prefix from `pip-` to `poetry-` for clarity and accuracy.
* Added a separate cache step for pip, using a key that includes the Python version and a `pip-` prefix, ensuring pip and Poetry caches are managed independently.

**Observability enhancements:**

* Added a step to report the sizes of both the Poetry and pip caches after the dependencies are installed, aiding in monitoring and debugging cache usage.