### PR TITLE
Refactor Docker build workflow for improved caching and logging

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,7 @@ on:
 jobs:
     build:
         runs-on: ubuntu-latest
+
         steps:
             - uses: actions/checkout@v6
 
@@ -33,16 +34,17 @@ jobs:
                 context: .
                 push: false
                 tags: yfinance-service:${{ github.sha }}
+
                 cache-from: type=gha
                 cache-to: type=gha,mode=max
 
                 provenance: false
                 sbom: false
-
                 outputs: type=docker
           
             - name: Inspect built image
               run: |
                 echo "Build completed at: $(date -u)"
+                docker image inspect yfinance-service:${{ github.sha }} > /dev/null
                 
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,24 +19,30 @@ jobs:
             - name: Setup Docker Buildx
               uses: docker/setup-buildx-action@v4
 
-            - name: Cache Docker layers
-              uses: actions/cache@v5
-              with:
-                path: .cache/buildx
-                key: buildx-${{ runner.os }}-${{ hashFiles('**/Dockerfile', '**/poetry.lock', '**/pyproject.toml') }}
-                restore-keys: |
-                  buildx-${{ runner.os }}-
-            
+            - name: Build metadata
+              run: |
+                echo "Git SHA: $GITHUB_SHA"
+                echo "Branch: $GITHUB_REF_NAME"
+                echo "Runner: $RUNNER_OS"
+                docker version
+                docker buildx ls
+
             - name: Build image (no push)
               uses: docker/build-push-action@v7
               with:
                 context: .
                 push: false
                 tags: yfinance-service:${{ github.sha }}
-                cache-from: type=local,src=.cache/buildx
-                cache-to: type=local,dest=.cache/buildx-new,mode=max
-            - name: Move new cache
-              if: always()
+                cache-from: type=gha
+                cache-to: type=gha,mode=max
+
+                provenance: false
+                sbom: false
+
+                outputs: type=docker
+          
+            - name: Inspect built image
               run: |
-                rm -rf .cache/buildx
-                mv .cache/buildx-new .cache/buildx
+                echo "Build completed at: $(date -u)"
+                
+


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for building Docker images. The main improvements are the switch to GitHub Actions cache for Docker layers, the addition of build metadata logging, and enhanced inspection of the built image.

**Workflow and Docker build improvements:**

* Switched Docker layer caching from local filesystem (`actions/cache`) to GitHub Actions cache (`type=gha`) for improved reliability and performance.
* Added a new step to log build metadata such as Git SHA, branch, runner OS, and Docker version for better traceability.
* Enhanced the Docker build step by disabling provenance and SBOM generation, and specifying Docker output type for clarity and reproducibility.
* Added a post-build inspection step to verify the built image and log the build completion time.This pull request updates the Docker build process in the GitHub Actions workflow to improve caching and add more metadata and inspection steps. The main changes are a switch to GitHub Actions cache for Docker layers, removal of local cache directory management, and the addition of build metadata and inspection steps.

**Build process improvements:**

* Switched Docker layer caching from a local directory (`.cache/buildx`) to GitHub Actions cache (`type=gha`), simplifying cache management and improving cache sharing across runners.
* Removed manual cache directory movement and cleanup steps, reducing workflow complexity.

**Build metadata and inspection:**

* Added a step to print build metadata (Git SHA, branch, runner OS, Docker version, and buildx instances) before building the image, improving traceability.
* Added a step to inspect the built image and log the build completion time for better visibility into the build process.

**Docker build options:**

* Disabled provenance and SBOM generation in the Docker build, and set the build output type to `docker` for clarity and potentially faster builds.