### PR TITLE
Add pytest-xdist for parallel test execution

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,8 @@ jobs:
 
       - name: Run tests
         run: > 
-          poetry run pytest 
+          poetry run pytest
+          -n auto --dist loadscope
           --maxfail=1 --disable-warnings --tb=short
           --cov=app
           --cov-report=term-missing 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ pylint = "^4.0.5"
 pytest-cov = "^7.1.0"
 httpx = "^0.28.1"
 pytest-asyncio = "^1.3.0"
+pytest-xdist = "^3.8.0"
 
 [tool.poetry.requires-plugins]
 poetry-plugin-export = ">=1.8"


### PR DESCRIPTION
This pull request introduces parallelization to the test suite by leveraging pytest-xdist, which should speed up test execution in CI. The most important changes are:

**Test execution improvements:**

* Updated the GitHub Actions workflow (`.github/workflows/test.yml`) to run pytest with the `-n auto --dist loadscope` options, enabling automatic parallel test execution and better load distribution.

**Dependency management:**

* Added `pytest-xdist` as a development dependency in `pyproject.toml` to support parallel test execution.