### PR TITLE
Fix zero size behavior in TTLCache to disable caching operations

### DIFF
--- a/app/utils/cache/ttl_in_memory.py
+++ b/app/utils/cache/ttl_in_memory.py
@@ -14,8 +14,7 @@ from .interface import CacheInterface, K, V
 
 
 class TTLCache(CacheInterface, Generic[K, V]):
-    """
-    An in-memory cache with time-to-live (TTL) expiration and FIFO eviction policy.
+    """An in-memory cache with time-to-live (TTL) expiration and FIFO eviction policy.
 
     This cache evicts the oldest inserted item when the maximum size is reached,
     following a FIFO (first-in, first-out) policy. It does not implement a
@@ -31,6 +30,7 @@ class TTLCache(CacheInterface, Generic[K, V]):
     for cache hits, misses, evictions, expirations, length, and puts, allowing
     for fine-grained monitoring of cache usage and performance.
     """
+
     def __init__(
         self, size: int, ttl: int, *, cache_name: str = "ttl_cache", resource: str = "generic"
     ) -> None:
@@ -59,6 +59,11 @@ class TTLCache(CacheInterface, Generic[K, V]):
 
     async def get(self, key: K) -> Optional[V]:
         async with self._lock:
+            # If cache disabled (size <= 0) treat as always-miss
+            if self.size <= 0:
+                self._misses.inc()
+                return None
+
             entry = self._cache.get(key)
             if entry is None:
                 self._misses.inc()
@@ -76,6 +81,10 @@ class TTLCache(CacheInterface, Generic[K, V]):
 
     async def set(self, key: K, value: V) -> None:
         async with self._lock:
+            # If cache disabled (size <= 0) do not store anything.
+            if self.size <= 0:
+                return
+
             # enforce max size by evicting oldest entry before inserting new key
             if key not in self._cache and len(self._cache) >= self.size:
                 oldest = next(iter(self._cache))
@@ -88,10 +97,16 @@ class TTLCache(CacheInterface, Generic[K, V]):
 
     async def delete(self, key: K) -> None:
         async with self._lock:
+            # If cache disabled, nothing to delete
+            if self.size <= 0:
+                return
             if self._cache.pop(key, None) is not None:
                 self._length.set(len(self._cache))
 
     async def clear(self) -> None:
         async with self._lock:
+            # If cache disabled, nothing to clear
+            if self.size <= 0:
+                return
             self._cache.clear()
             self._length.set(0)

--- a/tests/unit/utils/cache/test_ttl_cache.py
+++ b/tests/unit/utils/cache/test_ttl_cache.py
@@ -87,3 +87,21 @@ async def test_ttlcache_expiry_and_metrics():
     assert await c.get("x") is None
     # expiration counter incremented
     assert CACHE_EXPIRATIONS.labels(cache="test_cache2", resource="test2")._value.get() >= 1
+
+
+@pytest.mark.asyncio
+async def test_ttlcache_zero_size_behavior():
+    """When cache `size` is 0 the cache is disabled: gets miss and sets are no-ops."""
+    c = TTLCache(0, ttl=60, cache_name="test_cache_zero", resource="test_zero")
+
+    # reads always miss
+    assert await c.get("a") is None
+
+    # sets are no-ops and do not change length or put counters
+    await c.set("a", 1)
+    assert await c.get("a") is None
+    await c.delete("a")  # should be no-op and not raise
+    await c.clear()  # should be no-op and not raise
+
+    assert CACHE_LENGTH.labels(cache="test_cache_zero", resource="test_zero")._value.get() == 0
+    assert CACHE_PUTS.labels(cache="test_cache_zero", resource="test_zero")._value.get() == 0


### PR DESCRIPTION
This pull request improves the behavior of the `TTLCache` class when the cache size is set to zero, effectively disabling the cache. It ensures that all cache operations become no-ops in this case, and adds corresponding tests to verify this behavior.

**TTLCache zero-size (disabled) behavior:**

* Updated `TTLCache` methods (`get`, `set`, `delete`, `clear`) in `app/utils/cache/ttl_in_memory.py` to treat `size <= 0` as a disabled cache: all operations are no-ops and `get` always misses. [[1]](diffhunk://#diff-7a72197603464c466483c8a18c7347974d5f4bb30cca75b0b4ace240bdc6cafbR62-R66) [[2]](diffhunk://#diff-7a72197603464c466483c8a18c7347974d5f4bb30cca75b0b4ace240bdc6cafbR84-R87) [[3]](diffhunk://#diff-7a72197603464c466483c8a18c7347974d5f4bb30cca75b0b4ace240bdc6cafbR100-R110)
* Added a new test `test_ttlcache_zero_size_behavior` in `tests/unit/utils/cache/test_ttl_cache.py` to verify that the cache is disabled when `size` is zero and that metrics are not incremented incorrectly.

**Code style:**

* Minor docstring formatting improvement in `TTLCache` class. [[1]](diffhunk://#diff-7a72197603464c466483c8a18c7347974d5f4bb30cca75b0b4ace240bdc6cafbL17-R17) [[2]](diffhunk://#diff-7a72197603464c466483c8a18c7347974d5f4bb30cca75b0b4ace240bdc6cafbR33)