### PR TITLE
Replace internal normalization method with utility function

### DIFF
--- a/app/clients/yfinance_client.py
+++ b/app/clients/yfinance_client.py
@@ -32,6 +32,7 @@ from app.settings import Settings
 from app.utils.cache import TTLCache
 
 from ..monitoring.instrumentation import observe
+from ..utils.helpers import normalize_symbol
 from ..utils.logger import logger
 
 YFinanceData = dict[str, Any]
@@ -324,9 +325,7 @@ class YFinanceClient(YFinanceClientInterface):
                                 return call_result
 
                             async with self._upstream_sem:
-                                result = await asyncio.wait_for(
-                                    _invoke_fetch(), self._timeout
-                                )
+                                result = await asyncio.wait_for(_invoke_fetch(), self._timeout)
 
                         async with self._inflight_lock:
                             _e = self._inflight.pop(key, None)
@@ -474,18 +473,6 @@ class YFinanceClient(YFinanceClientInterface):
         """
         return await self._fetch_data_coalesced(op, fetch_func, symbol, *args, **kwargs)
 
-    def _normalize(self, symbol: str) -> str:
-        """Normalize a stock symbol to uppercase and strip whitespace.
-
-        Args:
-            symbol: The raw stock symbol string.
-
-        Returns:
-            Normalized symbol (uppercase, stripped). Empty string if symbol is None.
-
-        """
-        return (symbol or "").upper().strip()
-
     async def get_info(self, symbol: str) -> YFinanceData:
         """Fetch company information for a specific stock.
 
@@ -499,7 +486,7 @@ class YFinanceClient(YFinanceClientInterface):
             HTTPException: 404 if no data found, 502 if data format is invalid.
 
         """
-        symbol = self._normalize(symbol)
+        symbol = normalize_symbol(symbol)
         ticker = await self._get_ticker(symbol)
         info = await self._fetch_data("info", ticker.get_info, symbol)
         if not info:
@@ -528,7 +515,7 @@ class YFinanceClient(YFinanceClientInterface):
             HTTPException: 404 if no news found, 502 if data format is invalid.
 
         """
-        symbol = self._normalize(symbol)
+        symbol = normalize_symbol(symbol)
         # no_cache=True because yf.Ticker.get_news does not re-check its arguments
         # on a cached object — different count/tab values would silently return
         # the same cached result.
@@ -563,7 +550,7 @@ class YFinanceClient(YFinanceClientInterface):
             HTTPException: 404 if no data found, 502 if data format is invalid.
 
         """
-        symbol = self._normalize(symbol)
+        symbol = normalize_symbol(symbol)
         ticker = await self._get_ticker(symbol)
         history = await self._fetch_data(
             "history", ticker.history, symbol, start=start, end=end, interval=interval
@@ -603,7 +590,7 @@ class YFinanceClient(YFinanceClientInterface):
             HTTPException: If an HTTP error occurs during fetching.
 
         """
-        symbol = self._normalize(symbol)
+        symbol = normalize_symbol(symbol)
         ticker = await self._get_ticker(symbol)
 
         try:
@@ -694,7 +681,7 @@ class YFinanceClient(YFinanceClientInterface):
                 500 for other errors.
 
         """
-        symbol = self._normalize(symbol)
+        symbol = normalize_symbol(symbol)
         ticker = await self._get_ticker(symbol)
 
         try:
@@ -756,7 +743,7 @@ class YFinanceClient(YFinanceClientInterface):
             HTTPException: 404 if no split data is found.
 
         """
-        symbol = self._normalize(symbol)
+        symbol = normalize_symbol(symbol)
         ticker = await self._get_ticker(symbol)  # await — _get_ticker is async
 
         splits = await self._fetch_data("splits", lambda: ticker.splits, symbol)


### PR DESCRIPTION
This pull request refactors the symbol normalization logic in the `yfinance_client` by removing the internal `_normalize` method and consistently using a shared `normalize_symbol` utility function across all relevant methods. This change improves code reuse and maintainability by centralizing symbol normalization.

**Refactoring and Code Reuse:**

* Removed the `_normalize` method from `YFinanceClient` and replaced its usage with the shared `normalize_symbol` function imported from `app.utils.helpers`. This affects all methods that require symbol normalization, ensuring consistency across the client. [[1]](diffhunk://#diff-5b1206e1d1858d7e6398a05b44cb62d4ce26e9938bb551c693d243955d28ac05R35) [[2]](diffhunk://#diff-5b1206e1d1858d7e6398a05b44cb62d4ce26e9938bb551c693d243955d28ac05L477-L488)

* Updated all methods that previously called `self._normalize(symbol)` (`get_info`, `get_news`, `get_history`, `get_earnings`, `get_calendar`, `get_splits`) to now use `normalize_symbol(symbol)`. [[1]](diffhunk://#diff-5b1206e1d1858d7e6398a05b44cb62d4ce26e9938bb551c693d243955d28ac05L502-R489) [[2]](diffhunk://#diff-5b1206e1d1858d7e6398a05b44cb62d4ce26e9938bb551c693d243955d28ac05L531-R518) [[3]](diffhunk://#diff-5b1206e1d1858d7e6398a05b44cb62d4ce26e9938bb551c693d243955d28ac05L566-R553) [[4]](diffhunk://#diff-5b1206e1d1858d7e6398a05b44cb62d4ce26e9938bb551c693d243955d28ac05L606-R593) [[5]](diffhunk://#diff-5b1206e1d1858d7e6398a05b44cb62d4ce26e9938bb551c693d243955d28ac05L697-R684) [[6]](diffhunk://#diff-5b1206e1d1858d7e6398a05b44cb62d4ce26e9938bb551c693d243955d28ac05L759-R746)

**Minor Code Cleanup:**

* Minor formatting clean-up in the `_invoke_fetch` method for improved readability.