### PR TITLE
Update news cache labels and integrate metrics tracking

### DIFF
--- a/app/clients/yfinance_client.py
+++ b/app/clients/yfinance_client.py
@@ -32,6 +32,7 @@ from app.settings import Settings
 from app.utils.cache import TTLCache
 
 from ..monitoring.instrumentation import observe
+from ..monitoring.metrics import YF_REQUESTS, safe_metric_call
 from ..utils.helpers import normalize_symbol
 from ..utils.logger import logger
 
@@ -289,8 +290,8 @@ class YFinanceClient(YFinanceClientInterface):
             # Follower path
             try:
                 result = await asyncio.shield(follower_future)
-                if hasattr(observe, "record_metric"):
-                    observe.record_metric("YF_REQUESTS", 1, {"outcome": "cached_dedupe"})
+                # Record a dedupe metric for followers (use safe wrapper).
+                safe_metric_call(YF_REQUESTS.labels(operation=op, outcome="cached_dedupe").inc)
                 # Copy so this caller's mutations don't corrupt other waiters.
                 return _safe_copy(result)
             except asyncio.CancelledError:

--- a/app/utils/cache/news_cache.py
+++ b/app/utils/cache/news_cache.py
@@ -48,8 +48,8 @@ class NewsCache:
         self._index_cache: TTLCache[Key, list[str]] = TTLCache(
             size,
             ttl,
-            cache_name="ttl_cache",
-            resource="news",
+            cache_name=self._cache_name + "_index",
+            resource=self._resource + "_index",
         )
         # Labeled metric children for this cache instance
         self._hits = CACHE_HITS.labels(cache=self._cache_name, resource=self._resource)


### PR DESCRIPTION
This pull request makes targeted improvements to metrics tracking and cache naming in the codebase. The most important changes are grouped below:

**Metrics and Monitoring Improvements:**

* Replaced the old metric recording method in `yfinance_client.py` with a safer and more robust approach by using `safe_metric_call` and the `YF_REQUESTS` metric, ensuring deduplication events are correctly recorded.
* Added imports for `YF_REQUESTS` and `safe_metric_call` in `yfinance_client.py` to support the improved metric tracking.

**Cache Naming Consistency:**

* Updated the initialization of the `_index_cache` in `news_cache.py` to use more descriptive and consistent cache and resource names by appending `_index`, improving clarity and monitoring.