### PR TITLE
Add timezone cache location setting for yfinance

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ ENV PYTHONUNBUFFERED=1 \
     SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt \
     CURL_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
 
-RUN groupadd -r appuser && useradd -r -g appuser -d /home/appuser -s /usr/sbin/nologin -c "App user" appuser \
+RUN groupadd -r appuser && useradd -r -g appuser -d /home/appuser -s /usr/sbin/nologin -c "App user" appuser -m \
     && mkdir -p /app
 
 WORKDIR /app

--- a/app/main.py
+++ b/app/main.py
@@ -28,6 +28,11 @@ async def lifespan(app: FastAPI):
     # Set up logging from settings
     configure_logging(get_settings())
 
+    import yfinance as yf
+
+    if hasattr(yf, "set_tz_cache_location"):
+        yf.set_tz_cache_location(settings.yfinance_tz_cache_location)
+
     app.state.start_time = time.time()
     contact_name = None
     contact_email = None
@@ -36,7 +41,7 @@ async def lifespan(app: FastAPI):
         contact_email = app.contact.get("email")
     BUILD_INFO.info(
         {
-            "version": "0.0.27",
+            "version": app.version,
             "python_version": sys.version.split()[0],
             "contact_name": contact_name or "unknown",
             "contact_email": contact_email or "unknown",

--- a/app/settings.py
+++ b/app/settings.py
@@ -86,6 +86,8 @@ class Settings(BaseSettings):
         validation_alias="API_KEY_UNPROTECTED_ENDPOINTS",
     )
 
+    yfinance_tz_cache_location: str = Field("/tmp", validation_alias="YFINANCE_TZ_CACHE_LOCATION")
+
     @field_validator("log_level", mode="before")
     @classmethod
     def _upper(cls, v: str) -> str:


### PR DESCRIPTION
This pull request introduces configuration improvements for the application, particularly around the usage of the `yfinance` library and version reporting. The most significant changes are the addition of a configurable cache location for yfinance timezone data, dynamic version reporting, and a minor Dockerfile fix to ensure home directory creation.

**Configuration and Dependency Improvements:**

* Added a new `yfinance_tz_cache_location` setting to `Settings` in `app/settings.py`, allowing the cache directory for yfinance timezone data to be configured via the `YFINANCE_TZ_CACHE_LOCATION` environment variable.
* In `app/main.py`, updated the application startup (`lifespan`) to import yfinance and set its timezone cache location using the new setting if supported by the library.

**Build and Deployment:**

* In `Dockerfile`, modified the `useradd` command to include the `-m` flag, ensuring the home directory for `appuser` is created. This can prevent permission or path issues at runtime.

**Application Metadata:**

* Changed the version reporting in the `BUILD_INFO` logging (in `app/main.py`) to use `app.version` instead of a hardcoded version string, ensuring accurate version information is logged at startup.